### PR TITLE
Add focus-visible styles for improved keyboard accessibility

### DIFF
--- a/css/accessibility.css
+++ b/css/accessibility.css
@@ -9,4 +9,30 @@
     scroll-behavior: auto !important;
   }
 
+  .card {
+    transform: none !important;
+  }
+}
+
+\
+.card:focus-visible {
+  outline: 3px solid var(--text-color);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+/* Focus style for buttons and interactive controls */
+button:focus-visible,
+.preview-btn:focus-visible,
+a:focus-visible {
+  outline: 3px solid var(--text-color);
+  outline-offset: 3px;
+}
+
+/* Remove default focus outline for mouse users */
+.card:focus:not(:focus-visible),
+button:focus:not(:focus-visible),
+.preview-btn:focus:not(:focus-visible),
+a:focus:not(:focus-visible) {
+  outline: none;
 }


### PR DESCRIPTION
This PR introduces focus-visible styles to improve keyboard navigation
and accessibility without affecting mouse-based interactions.

- Adds clear focus indicators for cards, buttons, and links
- Applies styles only during keyboard navigation using :focus-visible
- Keeps the UI clean for mouse users
- Improves overall accessibility and usability

Tested locally using Live Server.
